### PR TITLE
Fix tutorials testing on `ubuntu-latest` runners

### DIFF
--- a/.github/workflows/testing_pr.yml
+++ b/.github/workflows/testing_pr.yml
@@ -147,6 +147,8 @@ jobs:
         for dir in $(ls -d tutorial*/); do
           if [[ $dir != tutorial5* ]]
             then
-            jupyter nbconvert --to notebook --execute ${dir}*.ipynb
+            cd $dir
+            jupyter nbconvert --to notebook --execute *.ipynb
+            cd ..
           fi
         done


### PR DESCRIPTION
Tutorial testing runs do not complete on `ubuntu-latest` because of incosistencies in the base location of `nbconvert --execute`. This should fix the problem.