### PR TITLE
Ignore extracted SegTrackv2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ pydmd\.egg-info/**
 
 **/\.ipynb_checkpoints/**
 **/SegTrackv2.zip
+**/SegTractv2/**
 
 # Vscode
 .vscode/**


### PR DESCRIPTION
I'm adding `**/SegTractv2/**` to `.gitignore` because this way `black` will ignore it: https://black.readthedocs.io/en/stable/usage_and_configuration/file_collection_and_discovery.html

We need to ignore it because otherwise black will fail on the Python 2 scripts which come with the file: https://github.com/PyDMD/PyDMD/actions/runs/4785241986/jobs/8507719956