### PR TITLE
Custom input functions for BOP-DMD eigenvalue constraints

### DIFF
--- a/pydmd/bopdmd.py
+++ b/pydmd/bopdmd.py
@@ -1082,7 +1082,7 @@ class BOPDMD(DMDBase):
         if isfunction(eig_constraints):
             if self._svd_rank >= 1 and isinstance(self._svd_rank, int):
                 r = self._svd_rank
-            else: # use a dummy rank of 10
+            else:  # use a dummy rank of 10
                 r = 10
 
             try:

--- a/pydmd/bopdmd.py
+++ b/pydmd/bopdmd.py
@@ -13,6 +13,7 @@ temporal uncertainty-quantification. 2021. arXiv:2107.10878.
 
 import warnings
 from collections import OrderedDict
+from inspect import isfunction
 from scipy.sparse import csr_matrix
 from scipy.linalg import qr
 import numpy as np
@@ -65,8 +66,10 @@ class BOPDMDOperator(DMDOperator):
         `"imag"`, which constrains eigenvalues to the imaginary axis, and
         `"conjugate_pairs"`, which enforces that eigenvalues are always
         present with their complex conjugate. Note that constraints may be
-        combined if valid.
-    :type eig_constraints: set(str)
+        combined if valid. May alternatively be a custom eigenvalue constraint
+        function that will be applied to the computed eigenvalues at each step
+        of the variable projection routine.
+    :type eig_constraints: set(str) or function
     :param init_lambda: Initial value used for the regularization parameter in
         the Levenberg method. Default is 1.0.
         Note: Larger lambda values make the method more like gradient descent.
@@ -255,13 +258,18 @@ class BOPDMDOperator(DMDOperator):
         Helper function that constrains the given eigenvalues according to
         the arguments found in self._eig_constraints. If no constraints were
         given, this function simply returns the given eigenvalues sorted
-        according to real part and then imaginary part to break ties.
+        according to real part and then imaginary part to break ties. Simply
+        applies the provided eig_constraints function and sorts the eigenvalues
+        if a function was provided instead of a set of constraints.
 
         :param eigenvalues: Vector of original eigenvalues.
         :type eigenvalues: numpy.ndarray
         :return: Vector of constrained eigenvalues.
         :rtype: numpy.ndarray
         """
+        if isfunction(self._eig_constraints):
+            return np.sort(self._eig_constraints(eigenvalues))
+
         if "conjugate_pairs" in self._eig_constraints:
             eigenvalues_sorted = np.sort(eigenvalues)
             num_eigs = len(eigenvalues)
@@ -827,8 +835,10 @@ class BOPDMD(DMDBase):
         `"imag"`, which constrains eigenvalues to the imaginary axis, and
         `"conjugate_pairs"`, which enforces that eigenvalues are always
         present with their complex conjugate. Note that constraints may be
-        combined if valid.
-    :type eig_constraints: set(str)
+        combined if valid. May alternatively be a custom eigenvalue constraint
+        function that will be applied to the computed eigenvalues at each step
+        of the variable projection routine.
+    :type eig_constraints: set(str) or function
     :param varpro_opts_dict: Dictionary containing the desired parameter values
         for variable projection. The following parameters may be specified:
         `init_lambda`, `maxlam`, `lamup`, `use_levmarq`, `maxiter`, `tol`,
@@ -870,10 +880,12 @@ class BOPDMD(DMDBase):
 
         if eig_constraints is None:
             eig_constraints = set()
-        elif not isinstance(eig_constraints, set):
-            raise ValueError("eig_constraints must be a set.")
+        elif not isinstance(eig_constraints, set) and not isfunction(
+            eig_constraints
+        ):
+            raise ValueError("eig_constraints must be a set or a function.")
+        self._check_eig_constraints(eig_constraints)
         self._eig_constraints = eig_constraints
-        self._check_eig_constraints()
 
         self._snapshots_holder = None
         self._time = None
@@ -1058,22 +1070,57 @@ class BOPDMD(DMDBase):
             else:
                 print(name + ":\t" + str(value))
 
-    def _check_eig_constraints(self):
+    def _check_eig_constraints(self, eig_constraints):
         """
-        Function that verifies that the set self._eig_constraints (1) does
-        not contain an unsupported constraint class, and (2) does not contain
-        an invalid combination of eigenvalue constraints.
+        Function that verifies that...
+         - if the given eig_constraints is a function, the function is able to
+         take an np.ndarray and return an np.ndarray
+         - if the given eig_constraints is a set, it does not contain an
+         unsupported constraint class, and does not contain an invalid
+         combination of eigenvalue constraints
         """
-        valid_constraints = {"stable", "imag", "conjugate_pairs"}
-        invalid_combos = [{"stable", "imag"}]
+        if isfunction(eig_constraints):
+            if self._svd_rank >= 1 and isinstance(self._svd_rank, int):
+                r = self._svd_rank
+            else: # use a dummy rank of 10
+                r = 10
 
-        if len(self._eig_constraints.difference(valid_constraints)) != 0:
-            raise ValueError("Invalid eigenvalue constraint provided.")
+            try:
+                # Test the eig_constraints function on a (r,) np.ndarray.
+                x_dummy = np.arange(r)
+                y_dummy = eig_constraints(x_dummy)
+            except Exception as e:
+                msg = (
+                    "eigenvalue constraint function must be able "
+                    "to take a single (n,) numpy.ndarray as input."
+                )
+                raise ValueError(msg) from e
 
-        for invalid_combo_set in invalid_combos:
-            if invalid_combo_set.issubset(self._eig_constraints):
-                msg = "Invalid eigenvalue constraint combination provided."
+            if not isinstance(y_dummy, np.ndarray):
+                msg = (
+                    "eigenvalue constraint function must "
+                    "output a single (n,) numpy.ndarray."
+                )
                 raise ValueError(msg)
+
+            if x_dummy.shape != y_dummy.shape:
+                msg = (
+                    "eigenvalue constraint function must accept a (n,) "
+                    "np.ndarray as input and output a (n,) np.ndarray."
+                )
+                raise ValueError(msg)
+
+        else:
+            valid_constraints = {"stable", "imag", "conjugate_pairs"}
+            invalid_combos = [{"stable", "imag"}]
+
+            if len(eig_constraints.difference(valid_constraints)) != 0:
+                raise ValueError("Invalid eigenvalue constraint provided.")
+
+            for invalid_combo_set in invalid_combos:
+                if invalid_combo_set.issubset(eig_constraints):
+                    msg = "Invalid eigenvalue constraint combination provided."
+                    raise ValueError(msg)
 
     def _initialize_alpha(self):
         """

--- a/pydmd/bopdmd.py
+++ b/pydmd/bopdmd.py
@@ -1074,7 +1074,7 @@ class BOPDMD(DMDBase):
         """
         Function that verifies that...
          - if the given eig_constraints is a function, the function is able to
-         take an np.ndarray and return an np.ndarray
+         take a (n,) numpy.ndarray and return a (n,) numpy.ndarray
          - if the given eig_constraints is a set, it does not contain an
          unsupported constraint class, and does not contain an invalid
          combination of eigenvalue constraints
@@ -1106,7 +1106,7 @@ class BOPDMD(DMDBase):
             if x_dummy.shape != y_dummy.shape:
                 msg = (
                     "eigenvalue constraint function must accept a (n,) "
-                    "np.ndarray as input and output a (n,) np.ndarray."
+                    "numpy.ndarray as input and output a (n,) numpy.ndarray."
                 )
                 raise ValueError(msg)
 

--- a/tests/test_bopdmd.py
+++ b/tests/test_bopdmd.py
@@ -251,6 +251,7 @@ def test_eig_constraints_errors_2():
     - eig_constraints takes multiple arguments
     - eig_constraints changes the shape of the input array
     """
+
     # Function that assumes the input is length 3.
     def bad_func_1(x):
         return np.multiply(x, np.arange(3))
@@ -313,6 +314,7 @@ def test_eig_constraints_2():
         setting eig_constraints={"imag"}
     - is a custom function, the functionality is as expected
     """
+
     def make_stable(x):
         right_half = x.real > 0.0
         x[right_half] = 1j * x[right_half].imag

--- a/tests/test_bopdmd.py
+++ b/tests/test_bopdmd.py
@@ -245,7 +245,7 @@ def test_eig_constraints():
 def test_eig_constraints_errors_2():
     """
     Tests that the BOPDMD module correctly throws an error upon initialization
-    whenever the eig_constraints is a function and...
+    whenever eig_constraints is a function and...
     - eig_constraints is incompatible with general (n,) numpy.ndarray inputs
     - eig_constraints doesn't return a single numpy.ndarray
     - eig_constraints takes multiple arguments
@@ -310,7 +310,7 @@ def test_eig_constraints_2():
     Tests that if the eig_constraints function...
     - discards positive real parts, the functionality is the same as
         setting eig_constraints={"stable"}
-    - discards real parts, the functionality is the same as
+    - discards all real parts, the functionality is the same as
         setting eig_constraints={"imag"}
     - is a custom function, the functionality is as expected
     """

--- a/tests/test_bopdmd.py
+++ b/tests/test_bopdmd.py
@@ -1,39 +1,38 @@
 import numpy as np
-from scipy.integrate import ode
+from scipy.integrate import solve_ivp
 from pytest import raises
+
 from pydmd.bopdmd import BOPDMD
 
 
-def f(t, y):
+def simulate_z(t_eval):
     """
-    y'(t) = f(t, y)
-    """
-    z1, z2 = y
-    z1_prime = z1 - 2 * z2
-    z2_prime = z1 - z2
-    return np.array((z1_prime, z2_prime))
-
-
-def simulate_z(t):
-    """
-    Given a time vector t = t1, t2, ..., evaluates and returns the snapshots
-    z(t1), z(t2), ... as columns of the matrix Z via explicit Runge-Kutta.
-
+    Given a time vector t_eval = t1, t2, ..., evaluates and returns
+    the snapshots z(t1), z(t2), ... as columns of the matrix Z.
     Simulates data z given by the system of ODEs
         z' = Az
     where A = [1 -2; 1 -1] and z_0 = [1, 0.1].
     """
-    z_0 = np.array((1.0, 0.1))
-    Z = np.empty((2, len(t)))
-    Z[:, 0] = z_0
-    r = ode(f).set_integrator("dopri5")
-    r.set_initial_value(z_0, t[0])
-    for i, t_i in enumerate(t):
-        if i == 0:
-            continue
-        r.integrate(t_i)
-        Z[:, i] = r.y
-    return Z
+
+    def ode_sys(zt, z):
+        z1, z2 = z
+        return [z1 - 2 * z2, z1 - z2]
+
+    # Set integrator keywords to replicate odeint defaults.
+    integrator_keywords = {}
+    integrator_keywords["rtol"] = 1e-12
+    integrator_keywords["method"] = "LSODA"
+    integrator_keywords["atol"] = 1e-12
+
+    sol = solve_ivp(
+        ode_sys,
+        [t_eval[0], t_eval[-1]],
+        [1.0, 0.1],
+        t_eval=t_eval,
+        **integrator_keywords
+    )
+
+    return sol.y
 
 
 def sort_imag(x):
@@ -241,3 +240,97 @@ def test_eig_constraints():
     bopdmd.fit(Z, t)
     assert np.all(bopdmd.eigs.real == 0.0)
     assert bopdmd.eigs[0].imag == -bopdmd.eigs[1].imag
+
+
+def test_eig_constraints_errors_2():
+    """
+    Tests that the BOPDMD module correctly throws an error upon initialization
+    whenever the eig_constraints is a function and...
+    - eig_constraints is incompatible with general (n,) numpy.ndarray inputs
+    - eig_constraints doesn't return a single numpy.ndarray
+    - eig_constraints takes multiple arguments
+    - eig_constraints changes the shape of the input array
+    """
+    # Function that assumes the input is length 3.
+    def bad_func_1(x):
+        return np.multiply(x, np.arange(3))
+
+    # Function that assumes the input array is at least 2-dimensional.
+    def bad_func_2(x):
+        return x[0, :] + x[1, :]
+
+    # Function that doesn't return an array.
+    def bad_func_3(x):
+        return len(x)
+
+    # Function that returns 2 arrays instead of 1.
+    def bad_func_4(x):
+        return x, 2 * x
+
+    # Function that accepts more than 1 input.
+    def bad_func_5(x, y):
+        return x + y
+
+    # Function that returns an array with a different shape.
+    def bad_func_6(x):
+        return x[:-1]
+
+    # Function that returns an array with an extra dimension.
+    def bad_func_7(x):
+        return x[:, None]
+
+    with raises(ValueError):
+        BOPDMD(eig_constraints=bad_func_1)
+
+    with raises(ValueError):
+        BOPDMD(eig_constraints=bad_func_2)
+
+    with raises(ValueError):
+        BOPDMD(eig_constraints=bad_func_3)
+
+    with raises(ValueError):
+        BOPDMD(eig_constraints=bad_func_4)
+
+    with raises(ValueError):
+        BOPDMD(eig_constraints=bad_func_5)
+
+    with raises(ValueError):
+        BOPDMD(eig_constraints=bad_func_6)
+
+    with raises(ValueError):
+        BOPDMD(eig_constraints=bad_func_7)
+
+    # See that bad_func_1 is fine if the svd_rank is 3.
+    BOPDMD(svd_rank=3, eig_constraints=bad_func_1)
+
+
+def test_eig_constraints_2():
+    """
+    Tests that if the eig_constraints function...
+    - discards positive real parts, the functionality is the same as
+        setting eig_constraints={"stable"}
+    - discards real parts, the functionality is the same as
+        setting eig_constraints={"imag"}
+    - is a custom function, the functionality is as expected
+    """
+    def make_stable(x):
+        right_half = x.real > 0.0
+        x[right_half] = 1j * x[right_half].imag
+        return x
+
+    def make_imag(x):
+        return 1j * x.imag
+
+    def make_real(x):
+        return x.real
+
+    bopdmd1 = BOPDMD(svd_rank=2, eig_constraints={"stable"}).fit(Z, t)
+    bopdmd2 = BOPDMD(svd_rank=2, eig_constraints=make_stable).fit(Z, t)
+    np.testing.assert_array_equal(bopdmd1.eigs, bopdmd2.eigs)
+
+    bopdmd1 = BOPDMD(svd_rank=2, eig_constraints={"imag"}).fit(Z, t)
+    bopdmd2 = BOPDMD(svd_rank=2, eig_constraints=make_imag).fit(Z, t)
+    np.testing.assert_array_equal(bopdmd1.eigs, bopdmd2.eigs)
+
+    bopdmd = BOPDMD(svd_rank=2, eig_constraints=make_real).fit(Z, t)
+    assert np.all(bopdmd.eigs.imag == 0.0)

--- a/tests/test_xyinput.py
+++ b/tests/test_xyinput.py
@@ -8,18 +8,30 @@ from pydmd.bopdmd import BOPDMD
 
 def simulate_z(t_eval):
     """
-    Given a time vector t_eval = t1, t2, ..., evaluates and returns the
-    snapshots z(t1), z(t2), ... as columns of the matrix Z via explicit
-    Runge-Kutta. Simulates data z given by the system of ODEs
+    Given a time vector t_eval = t1, t2, ..., evaluates and returns
+    the snapshots z(t1), z(t2), ... as columns of the matrix Z.
+    Simulates data z given by the system of ODEs
         z' = Az
     where A = [1 -2; 1 -1] and z_0 = [1, 0.1].
     """
 
-    def f(zt, z):
+    def ode_sys(zt, z):
         z1, z2 = z
         return [z1 - 2 * z2, z1 - z2]
 
-    sol = solve_ivp(f, [t_eval[0], t_eval[-1]], [1.0, 0.1], t_eval=t_eval)
+    # Set integrator keywords to replicate odeint defaults.
+    integrator_keywords = {}
+    integrator_keywords["rtol"] = 1e-12
+    integrator_keywords["method"] = "LSODA"
+    integrator_keywords["atol"] = 1e-12
+
+    sol = solve_ivp(
+        ode_sys,
+        [t_eval[0], t_eval[-1]],
+        [1.0, 0.1],
+        t_eval=t_eval,
+        **integrator_keywords
+    )
 
     return sol.y
 


### PR DESCRIPTION
Hi everyone!

This will probably be the last major BOP-DMD eigenvalue constraint feature update in a while, but since some users seem to occassionally be getting strange results when using the built in functions for constraining eigenvalues in the `BOPDMD` module, I've decided to add more customization options by allowing users to define and input their own eigenvalue constraint functions.

Basically, the previous functionality was that if users wanted to constrain their eigenvalues when applying BOP-DMD, they could provide a set of desired eigenvalue constraints via the `eig_constraints` parameter. The arguments provided would then activate a series of built in functions that would constrain the BOP-DMD eigenvalues at each iteration of the variable projection routine depending on the arguments.
```
bopdmd = BOPDMD(eig_constraints={"stable", "conjugate_pairs"})
```

This PR introduces the possibility of manually defining and inputting a custom function to be applied at each iteration of the variable projection routine. This way, users have the freedom to develop and input their own eigenvalue constraint functions in the event that they are either unhappy with the built in functions, or would like to enforce some sort of new type of eigenvalue constraint.
```
bopdmd = BOPDMD(eig_constraints=my_function)
```

In this PR, I include a variety of tests that ensure that `eig_constraints` can not only be a function, but it must also be a function that specifically takes in a single n-dimensional array and outputs a single n-dimensional array. I also test the functionality of the module for a small handful of cases. (Also included in this PR is a revision to my original ODE-solving code for better readability via the `solve_ivp` function, but this is more of a minor change.)