### PR TITLE
fix sklearn deprecation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ AUTHOR = meta["__author__"]
 VERSION = meta["__version__"]
 KEYWORDS = "dynamic-mode-decomposition dmd"
 
-REQUIRED = ["numpy", "scipy", "matplotlib", "sklearn"]
+REQUIRED = ["numpy", "scipy", "matplotlib", "scikit-learn"]
 
 EXTRAS = {
     "docs": ["Sphinx>=1.4", "sphinx_rtd_theme"],


### PR DESCRIPTION
From the failing tests:

      The 'sklearn' PyPI package is deprecated, use 'scikit-learn' rather than 'sklearn' for pip commands.
      
      Here is how to fix this error in the main use cases:
      - use 'pip install scikit-learn' rather than 'pip install sklearn'
      - replace 'sklearn' by 'scikit-learn' in your pip requirements files
        (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
      - if the 'sklearn' package is used by one of your dependencies,
        it would be great if you take some time to track which package uses
        'sklearn' instead of 'scikit-learn' and report it to their issue tracker
      - as a last resort, set the environment variable
        SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error
      
      More information is available at
      https://github.com/scikit-learn/sklearn-pypi-package