### PR TITLE
Edmd doc module

### DIFF
--- a/docs/source/bopdmd.rst
+++ b/docs/source/bopdmd.rst
@@ -1,5 +1,5 @@
-BOP-DMD
-=================
+BOPDMD: Optimized DMD and Bagging, Optimized DMD
+==================================================
 
 .. currentmodule:: pydmd.bopdmd
 
@@ -12,3 +12,9 @@ BOP-DMD
 	:show-inheritance:
 	:noindex:
 
+.. autoclass:: BOPDMDOperator
+	:members:
+	:private-members:
+	:undoc-members:
+	:show-inheritance:
+	:noindex:

--- a/docs/source/code.rst
+++ b/docs/source/code.rst
@@ -7,17 +7,23 @@ Code Documentation
 
 
    dmdbase
+   dmdoperator
    dmd
-   mrdmd
-   fbdmd
+   bopdmd
    cdmd
+   dmd_modes_tuner
+   dmdc
+   edmd
+   fbdmd
    hankeldmd
    havok
    hodmd
-   dmdc
+   mrdmd
    optdmd
-   spdmd
    paramdmd
+   plotter
+   pidmd
    rdmd
+   spdmd
    subspacedmd
-   dmd_modes_tuner
+   utils

--- a/docs/source/dmd_modes_tuner.rst
+++ b/docs/source/dmd_modes_tuner.rst
@@ -3,10 +3,9 @@ DMD Modes Tuner
 
 .. currentmodule:: pydmd.dmd_modes_tuner
 
-.. autoclass:: ModesTuner
-	:members:
-
 .. automodule:: pydmd.dmd_modes_tuner
+
+.. autoclass:: ModesTuner
 	:members:
 	:private-members:
 	:undoc-members:

--- a/docs/source/dmdoperator.rst
+++ b/docs/source/dmdoperator.rst
@@ -1,0 +1,13 @@
+DMD Operator
+==========================
+
+.. currentmodule:: pydmd.dmdoperator
+
+.. automodule:: pydmd.dmdoperator
+
+.. autoclass:: DMDOperator
+	:members:
+	:private-members:
+	:undoc-members:
+	:show-inheritance:
+	:noindex:

--- a/docs/source/edmd.rst
+++ b/docs/source/edmd.rst
@@ -1,18 +1,18 @@
-Physics-informed DMD
+Kernelized extended DMD
 ==========================
 
-.. currentmodule:: pydmd.pidmd
+.. currentmodule:: pydmd.edmd
 
-.. automodule:: pydmd.pidmd
+.. automodule:: pydmd.edmd
 
-.. autoclass:: PiDMD
+.. autoclass:: EDMD
 	:members:
 	:private-members:
 	:undoc-members:
 	:show-inheritance:
 	:noindex:
 
-.. autoclass:: PiDMDOperator
+.. autoclass:: EDMDOperator
 	:members:
 	:private-members:
 	:undoc-members:

--- a/docs/source/plotter.rst
+++ b/docs/source/plotter.rst
@@ -1,0 +1,14 @@
+Plotter
+==========================
+
+.. currentmodule:: pydmd.plotter
+
+.. automodule:: pydmd.plotter
+
+.. autofunction:: _enforce_ratio
+.. autofunction:: _plot_limits
+.. autofunction:: plot_eigs
+.. autofunction:: plot_eigs_mrdmd
+.. autofunction:: plot_modes_2D
+.. autofunction:: plot_snapshots_2D
+.. autofunction:: plot_summary

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -1,0 +1,11 @@
+Utilities
+==========================
+
+.. currentmodule:: pydmd.utils
+
+.. automodule:: pydmd.utils
+
+.. autofunction:: compute_rank
+.. autofunction:: compute_svd
+.. autofunction:: compute_tlsq
+.. autofunction:: pseudo_hankel_matrix

--- a/pydmd/edmd.py
+++ b/pydmd/edmd.py
@@ -80,7 +80,7 @@ class EDMDOperator(DMDOperator):
         :return: the (truncated) left-singular vectors matrix of the extended
             feature matrix, the (truncated) singular values matrix of the
             extended feature matrix, and the eigenvectors of the tranformed
-            forward operator `K_hat.
+            forward operator `K_hat`.
         :rtype: numpy.ndarray, numpy.ndarray, numpy.ndarray
         """
         # Compute kernel matrices using given snapshots and kernel function.

--- a/pydmd/edmd.py
+++ b/pydmd/edmd.py
@@ -80,7 +80,7 @@ class EDMDOperator(DMDOperator):
         :return: the (truncated) left-singular vectors matrix of the extended
             feature matrix, the (truncated) singular values matrix of the
             extended feature matrix, and the eigenvectors of the tranformed
-            forward operator K_hat.
+            forward operator `K_hat.
         :rtype: numpy.ndarray, numpy.ndarray, numpy.ndarray
         """
         # Compute kernel matrices using given snapshots and kernel function.


### PR DESCRIPTION
I added many missing doc modules. I organized the code page in the online documentation with the following criterion: first all the base dmd classes, and then I followed the alphabetical order of the modules.

This fixes also #351 