### PR TITLE
Fix missing submodules when using `pip install .`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ pydmd\.egg-info/**
 **/\.ipynb_checkpoints/**
 **/SegTrackv2.zip
 **/SegTrackv2/**
+build/**
 
 # Vscode
 .vscode/**

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 meta = {}
 with open("pydmd/meta.py") as fp:
@@ -74,7 +74,7 @@ setup(
     keywords=KEYWORDS,
     url=URL,
     license="MIT",
-    packages=[NAME],
+    packages=find_packages(),
     install_requires=REQUIRED,
     extras_require=EXTRAS,
     include_package_data=True,


### PR DESCRIPTION
Add find_packages() to setup.py

This change adds `find_packages()` to the `setup.py` file, which will include all subpackages in the installation process. This ensures that the submodules (such as `preprocessing`) are included when installing the project using `pip install .`.
