### PR TITLE
Requirements: `numpy<2`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ AUTHOR = meta["__author__"]
 VERSION = meta["__version__"]
 KEYWORDS = "dynamic-mode-decomposition dmd"
 
-REQUIRED = ["numpy", "scipy", "matplotlib", "scikit-learn"]
+REQUIRED = ["numpy<2", "scipy", "matplotlib", "scikit-learn"]
 
 EXTRAS = {
     "docs": ["Sphinx>=1.4", "sphinx_rtd_theme"],


### PR DESCRIPTION
[NumPy 2.0](https://github.com/numpy/numpy/issues/24300) is scheduled for release at some point during the coming winter: https://hackmd.io/@seberg/Bk5P9wJuj

We should evalute the [release notes](https://numpy.org/devdocs/release/2.0.0-notes.html) and the [migration guide](https://numpy.org/devdocs/numpy_2_0_migration_guide.html) before allowing users to pull it in along with PyDMD. For now it's safer to stay on `1.x`