### PR TITLE
Adding partial_amplitudes as an output for mrDMD

### DIFF
--- a/pydmd/mrdmd.py
+++ b/pydmd/mrdmd.py
@@ -392,6 +392,26 @@ Expected one item per level, got {} out of {} levels.""".format(
             [self.dmd_tree[level, leaf].eigs for leaf in leaves]
         )
 
+    def partial_amplitudes(self, level, node=None):
+        """
+        Return the amplitudes of the specific `level` and of the specific
+        `node`; if `node` is not specified, the method returns the amplitudes
+        of the given `level` (all the nodes).
+
+        :param int level: the index of the level from where the amplitudes are
+            extracted.
+        :param int node: the index of the node from where the amplitudes are
+            extracted; if None, the time evolution is extracted from all the
+            nodes of the given level. Default is None.
+
+        :return: the selected amplitudes stored by row
+        :rtype: numpy.ndarray
+        """
+        leaves = self.dmd_tree.index_leaves(level) if node is None else [node]
+        return np.concatenate(
+            [self.dmd_tree[level, leaf].amplitudes for leaf in leaves]
+        )
+
     def partial_reconstructed_data(self, level, node=None):
         """
         Return the reconstructed data computed using the modes and the time


### PR DESCRIPTION
This PR addresses issue #474 so as to have multi-resolution DMD also output `partial_amplitudes` for each level.