### PR TITLE
Add partial_amplitudes as an output of mrDMD

### DIFF
--- a/pydmd/mrdmd.py
+++ b/pydmd/mrdmd.py
@@ -405,7 +405,7 @@ Expected one item per level, got {} out of {} levels.""".format(
         return np.concatenate(
             [self.dmd_tree[level, leaf].amplitudes for leaf in leaves]
         )
-    
+
     def partial_reconstructed_data(self, level, node=None):
         """
         Return the reconstructed data computed using the modes and the time

--- a/pydmd/mrdmd.py
+++ b/pydmd/mrdmd.py
@@ -386,6 +386,26 @@ Expected one item per level, got {} out of {} levels.""".format(
             [self.dmd_tree[level, leaf].eigs for leaf in leaves]
         )
 
+    def partial_amplitudes(self, level, node=None):
+        """
+        Return the amplitudes of the specific `level` and of the specific
+        `node`; if `node` is not specified, the method returns the amplitudes
+        of the given `level` (all the nodes).
+
+        :param int level: the index of the level from where the amplitudes are
+            extracted.
+        :param int node: the index of the node from where the amplitudes are
+            extracted; if None, the amplitudes are extracted from all the
+            nodes of the given level. Default is None.
+
+        :return: the selected eigs
+        :rtype: numpy.ndarray
+        """
+        leaves = self.dmd_tree.index_leaves(level) if node is None else [node]
+        return np.concatenate(
+            [self.dmd_tree[level, leaf].amplitudes for leaf in leaves]
+        )
+    
     def partial_reconstructed_data(self, level, node=None):
         """
         Return the reconstructed data computed using the modes and the time

--- a/pydmd/rdmd.py
+++ b/pydmd/rdmd.py
@@ -7,7 +7,6 @@ Randomized dynamic mode decomposition. SIAM Journal on Applied Dynamical
 Systems, 18, 2019.
 """
 
-
 from .cdmd import CDMD
 from .utils import compute_rqb
 

--- a/tests/test_mrdmd.py
+++ b/tests/test_mrdmd.py
@@ -233,6 +233,28 @@ def test_partial_eigs2():
     assert peigs.shape == (rank,)
 
 
+def test_partial_eigs1():
+    max_level = 5
+    level = 2
+    rank = 2
+    dmd = DMD(svd_rank=rank)
+    mrdmd = MrDMD(dmd, max_level=max_level, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    pamps = mrdmd.partial_amplitudes(level)
+    assert pamps.shape == (rank * 2**level,)
+
+
+def test_partial_eigs2():
+    max_level = 5
+    level = 2
+    rank = 2
+    dmd = DMD(svd_rank=rank)
+    mrdmd = MrDMD(dmd, max_level=6, max_cycles=2)
+    mrdmd.fit(X=sample_data)
+    pamps = mrdmd.partial_amplitudes(level, 3)
+    assert pamps.shape == (rank,)
+
+
 def test_partial_reconstructed1():
     max_level = 5
     level = 2


### PR DESCRIPTION
This PR addresses #474 so as to also save `partial_amplitudes` per level for the outputs from multi-resolution DMD.