### PR TITLE
fix outdated docstrings

### DIFF
--- a/pydmd/utils.py
+++ b/pydmd/utils.py
@@ -277,19 +277,20 @@ def pseudo_hankel_matrix(X: np.ndarray, d: int) -> np.ndarray:
     :Example:
 
         >>> a = np.array([[1, 2, 3, 4, 5]])
-        >>> _hankel_pre_processing(a, d=2)
+        >>> pseudo_hankel_matrix(a, d=2)
         array([[1, 2, 3, 4],
                [2, 3, 4, 5]])
-        >>> _hankel_pre_processing(a, d=4)
+        >>> pseudo_hankel_matrix(a, d=4)
         array([[1, 2],
                [2, 3],
                [3, 4],
                [4, 5]])
-
+    
         >>> a = np.array([1,2,3,4,5,6]).reshape(2,3)
-        array([[1, 2, 3],
-               [4, 5, 6]])
-        >>> _hankel_pre_processing(a, d=2)
+        >>> print(a)
+        [[1 2 3]
+         [4 5 6]]
+        >>> pseudo_hankel_matrix(a, d=2)
         array([[1, 2],
                [4, 5],
                [2, 3],

--- a/pydmd/utils.py
+++ b/pydmd/utils.py
@@ -285,7 +285,7 @@ def pseudo_hankel_matrix(X: np.ndarray, d: int) -> np.ndarray:
                [2, 3],
                [3, 4],
                [4, 5]])
-    
+
         >>> a = np.array([1,2,3,4,5,6]).reshape(2,3)
         >>> print(a)
         [[1 2 3]


### PR DESCRIPTION
There was some outdated doctest in the `utils.py` dating from the last refactor (where a function name was changed but not the associated doctest). I made sure that 

```py
python -m doctest utils.py
```
was successful.

Are doctest not part of the current testing CI ? Seems like that could be fixed with a change of configuration for `pytest` (see here : https://docs.pytest.org/en/7.1.x/how-to/doctest.html)
