### PR TITLE
Fix not returning the video with added noise in Tutorial12: compressedDMD

### DIFF
--- a/tutorials/tutorial12/tutorial-12-cdmd.ipynb
+++ b/tutorials/tutorial12/tutorial-12-cdmd.ipynb
@@ -185,7 +185,7 @@
     "    if noise:\n",
     "        vid += np.random.normal(0, noise_amt, vid.shape)\n",
     "        vid = vid.clip(0, 1)\n",
-    "    return np.vstack(imgs).T, shape\n",
+    "    return vid, shape\n",
     "\n",
     "\n",
     "def get_video(object: str = \"frog\") -> np.ndarray:\n",


### PR DESCRIPTION
There's an option to add the noise to the original frames. However, after adding gaussian noise, the function returns the original frames.