### PR TITLE
Edit bopdmd.py's _initialize_alpha method for better memory by removing full matrix construction

### DIFF
--- a/pydmd/bopdmd.py
+++ b/pydmd/bopdmd.py
@@ -1368,7 +1368,8 @@ class BOPDMD(DMDBase):
         # Define the matrices Y and Z as the following and compute the
         # rank-truncated SVD of Y.
         Y = (ux1 + ux2) / 2
-        Z = (ux2 - ux1) / (self._time[1:] - self._time[:-1])  # Element-wise division by time differences. w/o large T
+        # Element-wise division by time differences. w/o large T
+        Z = (ux2 - ux1) / (self._time[1:] - self._time[:-1])  
         U, s, V = compute_svd(Y, self._svd_rank)
         S = np.diag(s)
 

--- a/pydmd/bopdmd.py
+++ b/pydmd/bopdmd.py
@@ -1365,15 +1365,10 @@ class BOPDMD(DMDBase):
         ux1 = ux[:, :-1]
         ux2 = ux[:, 1:]
 
-        # Define the diagonal matrix T as the following.
-        t1 = self._time[:-1]
-        t2 = self._time[1:]
-        T = np.diag(t2 - t1)
-
         # Define the matrices Y and Z as the following and compute the
         # rank-truncated SVD of Y.
         Y = (ux1 + ux2) / 2
-        Z = (ux2 - ux1).dot(np.linalg.inv(T))
+        Z = (ux2 - ux1) / (self._time[1:] - self._time[:-1])  # Element-wise division by time differences. w/o large T
         U, s, V = compute_svd(Y, self._svd_rank)
         S = np.diag(s)
 


### PR DESCRIPTION
This change request modifies the `_initialize_alpha` function in the dynamic mode decomposition implementation to enhance memory efficiency. The original implementation created a large diagonal matrix `T`, which led to excessive memory consumption for large datasets.

**Key Change**:
1. **Avoid Full Matrix Construction**: Replaced the construction of the full diagonal matrix `T` with direct element-wise operations. This approach significantly reduces memory usage. 

With these changes, I can handle larger datasets without encountering memory allocation errors.

Please review the changes for potential integration and feedback from the community. #539 