### PR TITLE
Bug fix for the variable projection algorithm of BOPDMD 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ dist/**
 
 # Virtual environment
 venv*/**
+.venv
+
+# Pyenv
+.python-version

--- a/pydmd/bopdmd.py
+++ b/pydmd/bopdmd.py
@@ -624,8 +624,8 @@ class BOPDMDOperator(DMDOperator):
             q_out, djac_out, j_pvt = qr(
                 djac_matrix, mode="economic", pivoting=True
             )
-            ij_pvt = np.arange(IA)
-            ij_pvt = ij_pvt[j_pvt]
+            ij_pvt = np.zeros(IA).astype(int)
+            ij_pvt[j_pvt] = np.arange(IA).astype(int)
             rjac[:IA] = np.triu(djac_out[:IA])
             rhs_top = q_out.conj().T.dot(rhs_temp)
             scales_pvt = scales[j_pvt[:IA]]

--- a/pydmd/bopdmd.py
+++ b/pydmd/bopdmd.py
@@ -624,8 +624,8 @@ class BOPDMDOperator(DMDOperator):
             q_out, djac_out, j_pvt = qr(
                 djac_matrix, mode="economic", pivoting=True
             )
-            ij_pvt = np.zeros(IA).astype(int)
-            ij_pvt[j_pvt] = np.arange(IA).astype(int)
+            ij_pvt = np.zeros(IA, dtype=int)
+            ij_pvt[j_pvt] = np.arange(IA, dtype=int)
             rjac[:IA] = np.triu(djac_out[:IA])
             rhs_top = q_out.conj().T.dot(rhs_temp)
             scales_pvt = scales[j_pvt[:IA]]


### PR DESCRIPTION
There is a small bug in the variable projection algorithm implemented in the `BOPDMD` class. This bug was causing the algorithm to fail to converge for certain "complex" signals (e.g. composed of three sine waves).

This is the [relevant line](https://github.com/duqbo/optdmd/blob/eff57045ab4085ae2b6a1a2decb583deeb1be488/src/varpro2.m#L272) in the original Matlab code.

I have made a [repo](https://github.com/dsj976/test-opt-dmd) were you can test these changes on a pre-generated dataset. Read the `README.md` for instructions.