### PR TITLE
Fixed failing mrCOSTS test

### DIFF
--- a/tests/test_mrcosts.py
+++ b/tests/test_mrcosts.py
@@ -150,7 +150,7 @@ expected_n_components = 2
 # Define the expected error in the reconstructions.
 expected_global_error = 0.053
 expected_lf_error = 0.10
-expected_hf_error = 0.17
+expected_hf_error = 0.16
 expected_transient_error = 0.3
 
 # Fit mrCOSTS for testing


### PR DESCRIPTION
Fix for the failing mrCOSTS tests. Works locally, looks like somehow the BOPDMD solver became a bit more robust, which is great. The change which caused the failing test/improved fitting came from an earlier pull request.