### PR TITLE
Bug fix: forecasting when using the fit_econ() method in BOPDMD

### DIFF
--- a/pydmd/bopdmd.py
+++ b/pydmd/bopdmd.py
@@ -1780,7 +1780,7 @@ class BOPDMD(DMDBase):
         if self.operator.eigenvalues_std is not None:
             # Compute num_trials many forecasts.
             all_x = np.empty(
-                (self._num_trials, self.snapshots.shape[0], len(t)),
+                (self._num_trials, self.proj_basis.shape[0], len(t)),
                 dtype="complex",
             )
 


### PR DESCRIPTION
When using the `fit_econ()` method the snapshots matrix is never passed to the `BOPDMD` instance. However, when bagging is used, the `forecast()` method currently attempts to access the `snapshots` attribute, which is `None` when `fit_econ()` is used. This PR replaces the call to the `snapshots` attribute by a call to the `proj_basis` attribute, which is always available and which will always have the same number of rows (spatial locations) as the snapshots matrix.